### PR TITLE
[Fix] 카드 댓글 기능 예외 처리 추가

### DIFF
--- a/src/main/java/com/sparta/hotsixproject/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sparta/hotsixproject/board/service/BoardServiceImpl.java
@@ -140,12 +140,12 @@ public class BoardServiceImpl implements BoardService{
                 .collect(Collectors.toList());
     }
 
-    private Board findBoard(Long id) {
+    public Board findBoard(Long id) {
         return boardRepository.findById(id).orElseThrow(() ->
                 new IllegalArgumentException("존재하지 않는 보드 입니다.")
         );
     }
-    private void checkBoardMember(User user, Board board) {
+    public void checkBoardMember(User user, Board board) {
         boardUserRepository.findByUserAndBoard(user, board).orElseThrow(() ->
                 new IllegalArgumentException("해당 보드 권한을 가진 유저가 아닙니다.")
         );

--- a/src/main/java/com/sparta/hotsixproject/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/hotsixproject/comment/controller/CommentController.java
@@ -35,8 +35,9 @@ public class CommentController {
     @GetMapping("/{boardId}/sides/{sideId}/cards/{cardId}/comments")
     @Operation(summary = "카드 댓글 조회", description = "해당 카드에 대한 모든 댓글을 조회합니다.")
     public ResponseEntity<ApiResponseDto> getComments(
-            @PathVariable Long boardId, @PathVariable Long sideId, @PathVariable Long cardId) {
-        CommentListResponseDto responseDto = commentService.getComments(boardId, sideId, cardId);
+            @PathVariable Long boardId, @PathVariable Long sideId, @PathVariable Long cardId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CommentListResponseDto responseDto = commentService.getComments(boardId, sideId, cardId, userDetails.getUser());
         return ResponseEntity.ok().body(responseDto);
     }
 

--- a/src/main/java/com/sparta/hotsixproject/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/hotsixproject/comment/service/CommentService.java
@@ -25,9 +25,10 @@ public interface CommentService {
      * @param boardId 보드 번호
      * @param sideId 사이드 번호
      * @param cardId 카드 번호
+     * @param user 댓글 조회 요청자
      * @return 선택한 게시글에 대한 전체 댓글 목록
      */
-    CommentListResponseDto getComments (Long boardId, Long sideId, Long cardId);
+    CommentListResponseDto getComments (Long boardId, Long sideId, Long cardId, User user);
 
     /**
      * 댓글 수정

--- a/src/main/java/com/sparta/hotsixproject/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sparta/hotsixproject/comment/service/CommentServiceImpl.java
@@ -35,7 +35,7 @@ public class CommentServiceImpl implements CommentService {
     @Override
     @Transactional(readOnly = true)
     @CommentCheckPageAndUser
-    public CommentListResponseDto getComments (Long boardId, Long sideId, Long cardId) {
+    public CommentListResponseDto getComments (Long boardId, Long sideId, Long cardId, User user) {
         Card card = findCard(cardId);
         return new CommentListResponseDto(commentRepository.findAllByCardOrderByCreatedAtDesc(card)
                 .stream().map(CommentResponseDto::new).toList());

--- a/src/main/java/com/sparta/hotsixproject/exception/aop/CommentCheckPageAndUserAspect.java
+++ b/src/main/java/com/sparta/hotsixproject/exception/aop/CommentCheckPageAndUserAspect.java
@@ -1,6 +1,7 @@
 package com.sparta.hotsixproject.exception.aop;
 
 import com.sparta.hotsixproject.board.entity.Board;
+import com.sparta.hotsixproject.board.service.BoardServiceImpl;
 import com.sparta.hotsixproject.card.entity.Card;
 import com.sparta.hotsixproject.comment.dto.CommentRequestDto;
 import com.sparta.hotsixproject.comment.entity.Comment;
@@ -18,26 +19,31 @@ import org.springframework.stereotype.Component;
 @Component
 public class CommentCheckPageAndUserAspect {
 	private final CommentServiceImpl commentService;
+	private final BoardServiceImpl boardService;
 
 	@Autowired
-	public CommentCheckPageAndUserAspect(CommentServiceImpl commentService) {
+	public CommentCheckPageAndUserAspect(CommentServiceImpl commentService, BoardServiceImpl boardService) {
 		this.commentService = commentService;
+		this.boardService = boardService;
 	}
 
 	@Before("@annotation(com.sparta.hotsixproject.exception.annotation.CommentCheckPageAndUser) && args(boardId, sideId, cardId, requestDto, user)")
 	public void commentCheckPage(Long boardId, Long sideId, Long cardId,
 								 CommentRequestDto requestDto, User user) {
+		boardUserCheck(boardId, user);
 		cardCheck(boardId, sideId, cardId);
 	}
 
-	@Before("@annotation(com.sparta.hotsixproject.exception.annotation.CommentCheckPageAndUser) && args(boardId, sideId, cardId)")
-	public void commentCheckPage(Long boardId, Long sideId, Long cardId) {
+	@Before("@annotation(com.sparta.hotsixproject.exception.annotation.CommentCheckPageAndUser) && args(boardId, sideId, cardId, user)")
+	public void commentCheckPage(Long boardId, Long sideId, Long cardId, User user) {
+		boardUserCheck(boardId, user);
 		cardCheck(boardId, sideId, cardId);
 	}
 
 	@Before("@annotation(com.sparta.hotsixproject.exception.annotation.CommentCheckPageAndUser) && args(boardId, sideId, cardId, commentId, requestDto, user)")
 	public void commentCheckPage(Long boardId, Long sideId, Long cardId,
 								 Long commentId, CommentRequestDto requestDto, User user) {
+		boardUserCheck(boardId, user);
 		commentCheck(boardId, sideId, cardId, commentId);
 		userCheckEdit(commentId, user);
 	}
@@ -45,6 +51,7 @@ public class CommentCheckPageAndUserAspect {
 	@Before("@annotation(com.sparta.hotsixproject.exception.annotation.CommentCheckPageAndUser) && args(boardId, sideId, cardId, commentId, user)")
 	public void commentCheckPage(Long boardId, Long sideId, Long cardId,
 								 Long commentId, User user) {
+		boardUserCheck(boardId, user);
 		commentCheck(boardId, sideId, cardId, commentId);
 		userCheckDelete(cardId, commentId, user);
 	}
@@ -55,7 +62,7 @@ public class CommentCheckPageAndUserAspect {
 		Card card = commentService.findCard(cardId);
 		Side side = card.getSide();
 		Board board = side.getBoard();
-		if (boardId != board.getId() || sideId != side.getId() || cardId != side.getId()) {
+		if (boardId != board.getId() || sideId != side.getId()) {
 			throw new NotFoundException("해당 페이지를 찾을 수 없습니다.");
 		}
 	}
@@ -84,5 +91,11 @@ public class CommentCheckPageAndUserAspect {
 		if (commentUser.getId() != user.getId() && cardUser.getId() != user.getId()) {
 			throw new UnauthorizedException("해당 댓글에 접근할 수 없습니다.");
 		}
+	}
+
+	// 보드의 참여자가 접근을 시도할 경우 예외 처리
+	private void boardUserCheck(Long boardId, User user) {
+		Board board = boardService.findBoard(boardId);
+		boardService.checkBoardMember(user, board);
 	}
 }


### PR DESCRIPTION
## 관련 이슈
https://github.com/HaenaCho01/hotsix-project/issues/23#issue-1841710398

## [Update] 카드 댓글 기능 예외 처리 추가
### 기존 코드 변경 내용
BoardServiceImpl 내 findBoard, checkBoarMember 메소드 private -> public 변경
`public Board findBoard(Long id)`
`public void checkBoardMember`

### 예외 처리 상황 추가 내용
- 사용자 권한 오류: 보드에 권한이 없는 사용자가 접근하고자 할 경우
<img width="426" alt="image" src="https://github.com/HaenaCho01/hotsix-project/assets/131599243/57d3852f-5da1-4f7d-9073-917f6943a82c">
<br><br>
<br><br>

## [Complete] 예외 처리 테스트 완료