### PR TITLE
[Feature] 카드에 작업자 추가

### DIFF
--- a/src/main/java/com/sparta/hotsixproject/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/hotsixproject/board/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.sparta.hotsixproject.board.controller;
 import com.sparta.hotsixproject.board.dto.BoardRequestDto;
 import com.sparta.hotsixproject.board.dto.BoardResponseDto;
 import com.sparta.hotsixproject.board.dto.InviteBoardRequestDto;
+import com.sparta.hotsixproject.board.dto.MemberResponseDto;
 import com.sparta.hotsixproject.board.service.BoardService;
 import com.sparta.hotsixproject.common.advice.ApiResponseDto;
 import com.sparta.hotsixproject.common.security.UserDetailsImpl;
@@ -62,5 +63,11 @@ public class BoardController {
     @PostMapping("/boards/{boardId}/members")
     public ResponseEntity<ApiResponseDto> inviteBoard(@PathVariable Long boardId, @RequestBody InviteBoardRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.status(HttpStatus.CREATED).body(boardService.inviteBoard(boardId,requestDto.getEmail(),userDetails.getUser()));
+    }
+
+    // 보드 멤버 전체 조회
+    @GetMapping("/boards/{boardId}/members")
+    public List<MemberResponseDto> getMembers(@PathVariable Long boardId) {
+        return boardService.getMembers(boardId);
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/board/dto/MemberResponseDto.java
+++ b/src/main/java/com/sparta/hotsixproject/board/dto/MemberResponseDto.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 
 @Getter
 public class MemberResponseDto {
+    private Long userId;
     private String nickname;
     private String email;
 
     public MemberResponseDto(BoardUser boardUser) {
+        this.userId = boardUser.getUser().getId();
         this.nickname = boardUser.getUser().getNickname();
         this.email = boardUser.getUser().getEmail();
     }

--- a/src/main/java/com/sparta/hotsixproject/board/dto/MemberResponseDto.java
+++ b/src/main/java/com/sparta/hotsixproject/board/dto/MemberResponseDto.java
@@ -1,0 +1,16 @@
+package com.sparta.hotsixproject.board.dto;
+
+import com.sparta.hotsixproject.board.entity.Board;
+import com.sparta.hotsixproject.board.entity.BoardUser;
+import lombok.Getter;
+
+@Getter
+public class MemberResponseDto {
+    private String nickname;
+    private String email;
+
+    public MemberResponseDto(BoardUser boardUser) {
+        this.nickname = boardUser.getUser().getNickname();
+        this.email = boardUser.getUser().getEmail();
+    }
+}

--- a/src/main/java/com/sparta/hotsixproject/board/repository/BoardUserRepository.java
+++ b/src/main/java/com/sparta/hotsixproject/board/repository/BoardUserRepository.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 
 @Repository
 public interface BoardUserRepository extends JpaRepository<BoardUser, Long> {
+    Optional<BoardUser> findByUser_EmailAndBoard_Id(String email, Long Id);
+    List<BoardUser> findByBoard_Id(Long Id);
     List<BoardUser> findAllByUser(User user);
 
     Optional<BoardUser> findByUserAndBoard(User user, Board board);

--- a/src/main/java/com/sparta/hotsixproject/board/service/BoardService.java
+++ b/src/main/java/com/sparta/hotsixproject/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.sparta.hotsixproject.board.service;
 
 import com.sparta.hotsixproject.board.dto.BoardRequestDto;
 import com.sparta.hotsixproject.board.dto.BoardResponseDto;
+import com.sparta.hotsixproject.board.dto.MemberResponseDto;
 import com.sparta.hotsixproject.common.advice.ApiResponseDto;
 import com.sparta.hotsixproject.user.entity.User;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,4 +25,7 @@ public interface BoardService {
     @Transactional
     ApiResponseDto deleteBoard(Long id, User user);
     ApiResponseDto inviteBoard(Long id, String email,User user);
+
+    @Transactional(readOnly = true)
+    List<MemberResponseDto> getMembers(Long boardId);
 }

--- a/src/main/java/com/sparta/hotsixproject/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sparta/hotsixproject/board/service/BoardServiceImpl.java
@@ -2,6 +2,7 @@ package com.sparta.hotsixproject.board.service;
 
 import com.sparta.hotsixproject.board.dto.BoardRequestDto;
 import com.sparta.hotsixproject.board.dto.BoardResponseDto;
+import com.sparta.hotsixproject.board.dto.MemberResponseDto;
 import com.sparta.hotsixproject.board.entity.Board;
 import com.sparta.hotsixproject.board.entity.BoardUser;
 import com.sparta.hotsixproject.board.repository.BoardRepository;
@@ -103,7 +104,7 @@ public class BoardServiceImpl implements BoardService{
 
     //보드 초대 메서드
     @Override
-    public ApiResponseDto inviteBoard(Long id, String email,User user) {
+    public ApiResponseDto inviteBoard(Long id, String email, User user) {
         User loginedUser = findUser(user.getId());
         Board targetBoard = findBoard(id);
         //로그인유저가 보드에 속한 유저인지 확인
@@ -125,6 +126,11 @@ public class BoardServiceImpl implements BoardService{
         return new ApiResponseDto(inviteUser.getNickname()+"님을 보드 멤버에 추가했습니다.",201);
     }
 
+    // 보드 멤버 전체 조회
+    @Override
+    public List<MemberResponseDto> getMembers(Long boardId) {
+        return boardUserRepository.findByBoard_Id(boardId).stream().map(MemberResponseDto::new).toList();
+    }
 
 
     // --private methods--

--- a/src/main/java/com/sparta/hotsixproject/card/controller/CardController.java
+++ b/src/main/java/com/sparta/hotsixproject/card/controller/CardController.java
@@ -37,6 +37,12 @@ public class CardController {
         return cardService.getCards(boardId, sideId);
     }
 
+    // 카드 작업자 추가
+    @PostMapping("/{boardId}/sides/{sideId}/cards/{cardId}/worker")
+    public ResponseEntity<CardResponseDto> addWorker(@PathVariable Long boardId, @PathVariable Long sideId, @PathVariable Long cardId, @RequestBody InviteCardRequestDto requestDto) {
+        return cardService.addWorker(boardId, sideId, cardId, requestDto.getEmail());
+    }
+
     // 카드 이름 수정
     @PutMapping("/{boardId}/sides/{sideId}/cards/{cardId}/name")
     public ResponseEntity<CardResponseDto> updateName(@PathVariable Long boardId, @PathVariable Long sideId, @PathVariable Long cardId,
@@ -71,14 +77,8 @@ public class CardController {
         return cardService.updateDueRemoval(boardId, sideId, cardId);
     }
 
-    // 카드 작업자 추가
-//    @PutMapping("/{boardId}/sides/{sideId}/cards/{cardId}/worker")
-//    public ResponseEntity<CardResponseDto> addWorker(@PathVariable Long boardId, @PathVariable Long sideId, @PathVariable Long cardId) {
-//        return cardService.addWorker(boardId, sideId, cardId);
-//    }
-
     // 카드 이동
-    @PutMapping("/{boardId}/sides/{sideId}/cards/{cardId}/move")
+    @PutMapping("/{boardId}/sides/{sideId}/cards/{cardId}/position")
     public ResponseEntity<CardResponseDto> moveCard(@PathVariable Long boardId, @PathVariable Long sideId, @PathVariable Long cardId,
                                                     @RequestBody MoveRequestDto requestDto ) {
         return cardService.moveCard(boardId, sideId, cardId, requestDto);

--- a/src/main/java/com/sparta/hotsixproject/card/dto/CardResponseDto.java
+++ b/src/main/java/com/sparta/hotsixproject/card/dto/CardResponseDto.java
@@ -1,6 +1,8 @@
 package com.sparta.hotsixproject.card.dto;
 
 import com.sparta.hotsixproject.card.entity.Card;
+import com.sparta.hotsixproject.user.dto.UserInfoDto;
+import com.sparta.hotsixproject.user.dto.UserInfoResponseDto;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -15,8 +17,7 @@ public class CardResponseDto {
     private int position;
     private LocalDateTime due;
     private boolean overdue;
-//    private LocalDateTime createdAt;
-//    private LocalDateTime modifiedAt;
+    private List<UserInfoResponseDto> userList;
 
     public CardResponseDto(Card card) {
         this.id = card.getId();
@@ -26,5 +27,6 @@ public class CardResponseDto {
         this.position = card.getPosition();
         this.due = card.getDue();
         this.overdue = due != null && due.isBefore(LocalDateTime.now());
+        this.userList = card.getCardUserList().stream().map((cardUser) -> new UserInfoResponseDto(cardUser.getUser())).toList();
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/card/dto/InviteCardRequestDto.java
+++ b/src/main/java/com/sparta/hotsixproject/card/dto/InviteCardRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.hotsixproject.card.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InviteCardRequestDto {
+    private String email;
+}

--- a/src/main/java/com/sparta/hotsixproject/card/entity/Card.java
+++ b/src/main/java/com/sparta/hotsixproject/card/entity/Card.java
@@ -5,6 +5,7 @@ import com.sparta.hotsixproject.attachment.entity.Attachment;
 import com.sparta.hotsixproject.board.entity.Board;
 import com.sparta.hotsixproject.card.dto.CardRequestDto;
 import com.sparta.hotsixproject.cardlabel.entity.CardLabel;
+import com.sparta.hotsixproject.carduser.entity.CardUser;
 import com.sparta.hotsixproject.comment.entity.Comment;
 import com.sparta.hotsixproject.common.entity.TimeStamped;
 import com.sparta.hotsixproject.side.entity.Side;
@@ -44,12 +45,14 @@ public class Card extends TimeStamped {
     @OneToMany(mappedBy = "card", orphanRemoval = true)
     private List<CardLabel> cardLabelList = new ArrayList<>();
 
-
     @OneToMany(mappedBy = "card", orphanRemoval = true)
     private List<Attachment> attachmentList = new ArrayList<>();
 
     @OneToMany(mappedBy = "card", orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "card", orphanRemoval = true)
+    private List<CardUser> cardUserList = new ArrayList<>();
 
     @ManyToOne
     @JoinColumn(nullable = false)

--- a/src/main/java/com/sparta/hotsixproject/card/repository/CardRepository.java
+++ b/src/main/java/com/sparta/hotsixproject/card/repository/CardRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CardRepository extends JpaRepository<Card, Long> {
@@ -13,4 +14,6 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     List<Card> findBySide_Board_IdAndSide_Id(Long id, Long id1);
     Card findBySide_Board_IdAndSide_IdAndId(Long id, Long id1, Long id2);
 
+    @Override
+    Optional<Card> findById(Long id);
 }

--- a/src/main/java/com/sparta/hotsixproject/card/service/CardService.java
+++ b/src/main/java/com/sparta/hotsixproject/card/service/CardService.java
@@ -13,6 +13,7 @@ import com.sparta.hotsixproject.card.repository.CardRepository;
 import com.sparta.hotsixproject.carduser.entity.CardUser;
 import com.sparta.hotsixproject.carduser.repository.CardUserRepository;
 import com.sparta.hotsixproject.common.advice.ApiResponseDto;
+import com.sparta.hotsixproject.exception.UnauthorizedException;
 import com.sparta.hotsixproject.side.entity.Side;
 import com.sparta.hotsixproject.side.repository.SideRepository;
 import com.sparta.hotsixproject.user.entity.User;
@@ -150,8 +151,7 @@ public class CardService {
     public ResponseEntity<ApiResponseDto> deleteCard(Long boardId, Long sideId, Long cardId, User user) {
         Card card = cardRepository.findBySide_Board_IdAndSide_IdAndId(boardId, sideId, cardId);
         if (!card.getUser().equals(user)) {
-            ApiResponseDto apiResponseDto = new ApiResponseDto("삭제 권한 없음", HttpStatus.UNAUTHORIZED.value());
-            return new ResponseEntity<>(apiResponseDto, HttpStatus.UNAUTHORIZED);
+            throw new UnauthorizedException("삭제 권한 없음");
         }
         cardRepository.delete(card);
         ApiResponseDto apiResponseDto = new ApiResponseDto("삭제 완료", HttpStatus.OK.value());

--- a/src/main/java/com/sparta/hotsixproject/card/service/CardService.java
+++ b/src/main/java/com/sparta/hotsixproject/card/service/CardService.java
@@ -39,7 +39,6 @@ public class CardService {
     public ResponseEntity<ApiResponseDto> createCard(Long sideId, String name, User user) {
         Side side = sideRepository.findById(sideId).get();
         Card card = new Card(name, side.getCardList().size() + 1, user, side);
-        cardRepository.save(card);
 
         CardUser cardUser = new CardUser(card, user);
         cardUserRepository.save(cardUser);

--- a/src/main/java/com/sparta/hotsixproject/carduser/entity/CardUser.java
+++ b/src/main/java/com/sparta/hotsixproject/carduser/entity/CardUser.java
@@ -16,7 +16,7 @@ public class CardUser {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @JoinColumn
     private Card card;
 

--- a/src/main/java/com/sparta/hotsixproject/carduser/entity/CardUser.java
+++ b/src/main/java/com/sparta/hotsixproject/carduser/entity/CardUser.java
@@ -1,0 +1,31 @@
+package com.sparta.hotsixproject.carduser.entity;
+
+import com.sparta.hotsixproject.card.entity.Card;
+import com.sparta.hotsixproject.label.entity.Label;
+import com.sparta.hotsixproject.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CardUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Card card;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private User user;
+
+    public CardUser(Card card, User user) {
+        this.card = card;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/sparta/hotsixproject/carduser/repository/CardUserRepository.java
+++ b/src/main/java/com/sparta/hotsixproject/carduser/repository/CardUserRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.hotsixproject.carduser.repository;
+
+import com.sparta.hotsixproject.carduser.entity.CardUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CardUserRepository extends JpaRepository<CardUser, Long> {
+    Optional<CardUser> findByCard_IdAndUser_Email(Long id, String email);
+}

--- a/src/main/java/com/sparta/hotsixproject/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/sparta/hotsixproject/user/dto/UserInfoResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.hotsixproject.user.dto;
+
+import com.sparta.hotsixproject.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UserInfoResponseDto {
+    private Long userId;
+    private String nickname;
+    private String email;
+
+    public UserInfoResponseDto(User user) {
+        this.userId = user.getId();
+        this.nickname = user.getNickname();
+        this.email = user.getEmail();
+    }
+}

--- a/src/main/java/com/sparta/hotsixproject/user/entity/User.java
+++ b/src/main/java/com/sparta/hotsixproject/user/entity/User.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(exclude = {"boardList", "cardList"})
+@EqualsAndHashCode(exclude = {"boardList", "cardList", "cardUserList"})
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sparta/hotsixproject/user/entity/User.java
+++ b/src/main/java/com/sparta/hotsixproject/user/entity/User.java
@@ -3,6 +3,7 @@ package com.sparta.hotsixproject.user.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sparta.hotsixproject.board.entity.Board;
 import com.sparta.hotsixproject.card.entity.Card;
+import com.sparta.hotsixproject.carduser.entity.CardUser;
 import com.sparta.hotsixproject.user.UserRoleEnum;
 import jakarta.persistence.*;
 import lombok.*;
@@ -38,6 +39,9 @@ public class User {
     @OneToMany(mappedBy = "user", orphanRemoval = true)
     private List<Card> cardList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
+    private List<CardUser> cardUserList = new ArrayList<>();
+
     public User(String nickname, String password, String email, UserRoleEnum role) {
         this.nickname=nickname;
         this.password=password;
@@ -45,7 +49,7 @@ public class User {
         this.role=role;
     }
 
-    public void updateNicknmae(String nickname) {
+    public void updateNickname(String nickname) {
         this.nickname=nickname;
     }
 

--- a/src/main/java/com/sparta/hotsixproject/user/service/UserService.java
+++ b/src/main/java/com/sparta/hotsixproject/user/service/UserService.java
@@ -86,7 +86,7 @@ public class UserService {
 
             );}
 
-        newuser.updateNicknmae(requestDto.getNickname());
+        newuser.updateNickname(requestDto.getNickname());
 
     }
     @Transactional

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
 
-spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.show_sql=false
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 


### PR DESCRIPTION
## 세부 전달 사항
- Card에 작업자들을 할당하기 위해 CardUser 패키지를 만들었습니다.

- 프론트에서 카드 작업자 추가를 눌렀을 때 보드 멤버 리스트를 불러 올 수 있도록 하고 포스트맨에서 테스트를 편하게 하려고 보드 멤버 전체 조회 api 추가했어요. (보드 멤버 추가 api에 response msg를 내려주는 방식이 아닌 dto로 내려줘도 좋을 것 같아요.)
**현재는 nickname과 email을 내려주는데 프론트 구현 방식에 따라 변경될 수 있습니다.** 
![image](https://github.com/HaenaCho01/hotsix-project/assets/78305720/f782460c-4cf4-4271-9637-2c7e35003933)

- 카드에 작업자 추가
보드에 추가된 멤버 내에서 카드에 작업자를 추가 할 수 있도록 있습니다.
![image](https://github.com/HaenaCho01/hotsix-project/assets/78305720/67101cb4-d070-4e33-9667-a88145d570a5)


